### PR TITLE
Replace queue ListTile with SongListTile

### DIFF
--- a/lib/screens/player_screen.dart
+++ b/lib/screens/player_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:just_audio/just_audio.dart';
 import '../models/song.dart';
 import '../services/playlist_service.dart';
+import '../widgets/song_list_tile.dart';
 import 'playlists_screen.dart';
 
 class PlayerScreen extends StatefulWidget {
@@ -505,7 +506,10 @@ class _PlayerScreenState extends State<PlayerScreen> {
                           (context, idx) {
                             final song = widget.songs[idx];
                             final isCurrent = idx == _currentIndex;
-                            return GestureDetector(
+                            return SongListTile(
+                              song: song,
+                              showBpm: true,
+                              selected: isCurrent,
                               onTap: () {
                                 setState(() {
                                   _currentIndex = idx;
@@ -513,88 +517,6 @@ class _PlayerScreenState extends State<PlayerScreen> {
                                 });
                                 _initAudioPlayer();
                               },
-                              child: Container(
-                                color: isCurrent
-                                    ? Theme.of(context)
-                                        .colorScheme
-                                        .primary
-                                        .withOpacity(0.15)
-                                    : Colors.transparent,
-                                child: ListTile(
-                                  leading: song.albumArt != null
-                                      ? ClipRRect(
-                                          borderRadius:
-                                              BorderRadius.circular(6),
-                                          child: Image.memory(
-                                            song.albumArt!,
-                                            width: 56,
-                                            height: 56,
-                                            fit: BoxFit.cover,
-                                          ),
-                                        )
-                                      : Container(
-                                          width: 56,
-                                          height: 56,
-                                          decoration: BoxDecoration(
-                                            color: Theme.of(context)
-                                                .colorScheme
-                                                .primary,
-                                            borderRadius:
-                                                BorderRadius.circular(6),
-                                          ),
-                                          child: const Icon(Icons.music_note,
-                                              color: Colors.black, size: 32),
-                                        ),
-                                  title: Text(
-                                    song.title ?? 'Unknown Title',
-                                    style: TextStyle(
-                                      fontWeight: FontWeight.bold,
-                                      fontSize: 16,
-                                      color: isCurrent
-                                          ? Theme.of(context)
-                                              .colorScheme
-                                              .primary
-                                          : Colors.white,
-                                    ),
-                                    maxLines: 1,
-                                    overflow: TextOverflow.ellipsis,
-                                  ),
-                                  subtitle: Text(
-                                    [
-                                      song.artist,
-                                      if (song.year != null)
-                                        song.year.toString(),
-                                    ]
-                                        .where((e) => e != null && e.isNotEmpty)
-                                        .join(' | '),
-                                    style: const TextStyle(
-                                        fontSize: 13, color: Colors.white70),
-                                    maxLines: 1,
-                                    overflow: TextOverflow.ellipsis,
-                                  ),
-                                  trailing: song.bpm != null
-                                      ? Container(
-                                          padding: const EdgeInsets.symmetric(
-                                              horizontal: 12, vertical: 6),
-                                          decoration: BoxDecoration(
-                                            color: Theme.of(context)
-                                                .colorScheme
-                                                .primary,
-                                            borderRadius:
-                                                BorderRadius.circular(20),
-                                          ),
-                                          child: Text(
-                                            'BPM ${song.bpm}',
-                                            style: const TextStyle(
-                                              color: Colors.white,
-                                              fontWeight: FontWeight.bold,
-                                              fontSize: 13,
-                                            ),
-                                          ),
-                                        )
-                                      : null,
-                                ),
-                              ),
                             );
                           },
                           childCount: widget.songs.length,

--- a/lib/widgets/song_list_tile.dart
+++ b/lib/widgets/song_list_tile.dart
@@ -1,0 +1,102 @@
+import 'package:flutter/material.dart';
+
+import '../models/song.dart';
+
+class SongListTile extends StatelessWidget {
+  final Song song;
+  final bool showBpm;
+  final bool selected;
+  final VoidCallback? onTap;
+
+  const SongListTile({
+    super.key,
+    required this.song,
+    this.showBpm = false,
+    this.selected = false,
+    this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    Widget leading;
+    if (song.albumArt != null) {
+      leading = ClipRRect(
+        borderRadius: BorderRadius.circular(6),
+        child: Image.memory(
+          song.albumArt!,
+          width: 56,
+          height: 56,
+          fit: BoxFit.cover,
+        ),
+      );
+    } else {
+      leading = Container(
+        width: 56,
+        height: 56,
+        decoration: BoxDecoration(
+          color: Theme.of(context).colorScheme.primary,
+          borderRadius: BorderRadius.circular(6),
+        ),
+        child: const Icon(Icons.music_note, color: Colors.black, size: 32),
+      );
+    }
+
+    final title = Text(
+      song.title ?? 'Unknown Title',
+      style: TextStyle(
+        fontWeight: FontWeight.bold,
+        fontSize: 16,
+        color: selected
+            ? Theme.of(context).colorScheme.primary
+            : Colors.white,
+      ),
+      maxLines: 1,
+      overflow: TextOverflow.ellipsis,
+    );
+
+    final subtitle = Text(
+      [
+        song.artist,
+        if (song.year != null) song.year.toString(),
+      ].where((e) => e != null && e.isNotEmpty).join(' | '),
+      style: const TextStyle(fontSize: 13, color: Colors.white70),
+      maxLines: 1,
+      overflow: TextOverflow.ellipsis,
+    );
+
+    Widget? trailing;
+    if (showBpm && song.bpm != null) {
+      trailing = Container(
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+        decoration: BoxDecoration(
+          color: Theme.of(context).colorScheme.primary,
+          borderRadius: BorderRadius.circular(20),
+        ),
+        child: Text(
+          'BPM ${song.bpm}',
+          style: const TextStyle(
+            color: Colors.white,
+            fontWeight: FontWeight.bold,
+            fontSize: 13,
+          ),
+        ),
+      );
+    }
+
+    final tile = ListTile(
+      leading: leading,
+      title: title,
+      subtitle: subtitle,
+      trailing: trailing,
+      contentPadding: const EdgeInsets.symmetric(horizontal: 16),
+      onTap: onTap,
+    );
+
+    return Container(
+      color: selected
+          ? Theme.of(context).colorScheme.primary.withOpacity(0.15)
+          : Colors.transparent,
+      child: tile,
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add reusable `SongListTile` widget
- use `SongListTile` in `PlayerScreen` for queue songs

## Testing
- `dart format lib/screens/player_screen.dart lib/widgets/song_list_tile.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686fdfe54f7083339d5c83dd6b1c25c4